### PR TITLE
chore: `.gitignore`に機密ファイルを追加 & `application.yml`をシンプル化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### Mooney's ###
+src/main/resources/application-secret.yml
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,31 +1,3 @@
 spring:
-  datasource:
-    url: ${SPRING_DATASOURCE_URL}
-    username: ${SPRING_DATASOURCE_USERNAME}
-    password: ${SPRING_DATASOURCE_PASSWORD}
-    driver-class-name: org.postgresql.Driver
-  security:
-    user:
-      name: ${APP_USERNAME:user}
-      password: ${APP_PASSWORD:pass}
-  flyway:
-    enabled: true
-    locations: classpath:db/migration
-
-logging:
-  level:
-    com.example.mooneys.mapper: DEBUG
-
-mybatis:
-  type-aliases-package: com.example.mooneys.entity
-  mapper-locations:
-    - classpath:mapper/*.xml
-    - classpath:mapper/custom/*.xml
-  configuration:
-    map-underscore-to-camel-case: true
-
-server:
-  error:
-    include-stacktrace: always
-
-debug: true
+  profiles:
+    active: secret


### PR DESCRIPTION
機密情報の管理を強化するため、`.gitignore`に`application-secret.yml`を追加。また、環境プロファイルの設定を外部化する目的で`application.yml`の内容を簡素化し`active: secret`のみに変更。