### PR TITLE
chore: `.gitignore` に `docker-compose*.yml` を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,4 @@ build/
 
 ### Mooney's ###
 src/main/resources/application-secret.yml
-
+docker-compose*.yml


### PR DESCRIPTION
`docker-compose` ファイルをバージョン管理対象外にするため。